### PR TITLE
Specified temp dirs to solve "OSError: AF_UNIX path too long"

### DIFF
--- a/modules/local/checkm2/main.nf
+++ b/modules/local/checkm2/main.nf
@@ -50,7 +50,7 @@ process CHECKM2 {
     fi
 
     echo "checkm predict"
-    mkdir checkm_tmp
+    mkdir -p checkm_tmp
     checkm2 predict --threads ${task.cpus} \
         --input bins_folder \
         -x fa \

--- a/modules/local/gtdbtk/main.nf
+++ b/modules/local/gtdbtk/main.nf
@@ -22,7 +22,7 @@ process GTDBTK {
     """
     export GTDBTK_DATA_PATH=/opt/gtdbtk_refdata
 
-    mkdir gtdbtk_tmp
+    mkdir -p gtdbtk_tmp
     gtdbtk classify_wf \
         --cpus ${task.cpus} \
         --pplacer_cpus ${task.cpus} \


### PR DESCRIPTION
Checkm2 and gtdbtk were facing this issue, this seems to solve it. @jmattock5 I just involved you here so that you know when it's merged!