### PR TITLE
Added zcat when counting contigs in the initial FASTA file

### DIFF
--- a/modules/nf-core/maxbin2/main.nf
+++ b/modules/nf-core/maxbin2/main.nf
@@ -56,8 +56,8 @@ process MAXBIN2 {
                 exit \$MAXBIN_EXITCODE
             else
                 echo "Checking for all contigs were moved to .tooshort file"
-                export INITIAL_NUMBER=\$(zcat $contigs | grep '>' | wc -l)
-                export TOO_SHORT_NUMBER=\$(grep '>' ${prefix}.tooshort | wc -l)
+                export INITIAL_NUMBER=\$(zgrep -c '>' $contigs)
+                export TOO_SHORT_NUMBER=\$(grep -c '>' ${prefix}.tooshort)
                 if [[ \$INITIAL_NUMBER -eq \$TOO_SHORT_NUMBER ]]; then
                     echo "All contigs are short"
                     gzip *log

--- a/modules/nf-core/maxbin2/main.nf
+++ b/modules/nf-core/maxbin2/main.nf
@@ -56,7 +56,7 @@ process MAXBIN2 {
                 exit \$MAXBIN_EXITCODE
             else
                 echo "Checking for all contigs were moved to .tooshort file"
-                export INITIAL_NUMBER=\$(grep '>' $contigs | wc -l)
+                export INITIAL_NUMBER=\$(zcat $contigs | grep '>' | wc -l)
                 export TOO_SHORT_NUMBER=\$(grep '>' ${prefix}.tooshort | wc -l)
                 if [[ \$INITIAL_NUMBER -eq \$TOO_SHORT_NUMBER ]]; then
                     echo "All contigs are short"

--- a/modules/nf-core/maxbin2/maxbin2.diff
+++ b/modules/nf-core/maxbin2/maxbin2.diff
@@ -73,7 +73,7 @@ Changes in module 'nf-core/maxbin2'
 +                exit \$MAXBIN_EXITCODE
 +            else
 +                echo "Checking for all contigs were moved to .tooshort file"
-+                export INITIAL_NUMBER=\$(grep '>' $contigs | wc -l)
++                export INITIAL_NUMBER=\$(zcat $contigs | grep '>' | wc -l)
 +                export TOO_SHORT_NUMBER=\$(grep '>' ${prefix}.tooshort | wc -l)
 +                if [[ \$INITIAL_NUMBER -eq \$TOO_SHORT_NUMBER ]]; then
 +                    echo "All contigs are short"

--- a/modules/nf-core/maxbin2/maxbin2.diff
+++ b/modules/nf-core/maxbin2/maxbin2.diff
@@ -73,8 +73,8 @@ Changes in module 'nf-core/maxbin2'
 +                exit \$MAXBIN_EXITCODE
 +            else
 +                echo "Checking for all contigs were moved to .tooshort file"
-+                export INITIAL_NUMBER=\$(zcat $contigs | grep '>' | wc -l)
-+                export TOO_SHORT_NUMBER=\$(grep '>' ${prefix}.tooshort | wc -l)
++                export INITIAL_NUMBER=\$(zgrep -c '>' $contigs)
++                export TOO_SHORT_NUMBER=\$(grep -c '>' ${prefix}.tooshort)
 +                if [[ \$INITIAL_NUMBER -eq \$TOO_SHORT_NUMBER ]]; then
 +                    echo "All contigs are short"
 +                    gzip *log


### PR DESCRIPTION
The check that compares the number of short sequences and the total number of sequences in the maxbin2 module wasn't working correctly because the original FASTA file is gzipped. Added zcat to count the contigs in the gzipped file.