### PR TITLE
Fix bin/mag alias when submitting to ENA

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If you will use ENA data follow [instructions](input_generation/README.md). Othe
 
 Each row corresponds to a specific dataset with information such as an `identifier` for the row, the file path to the assembly (`assembly`), and paths to the raw reads files (`fastq_1` and `fastq_2`). Additionally, the `assembly_accession` column contains associated assembly accessions. 
 
-| id         | assembly                  | fastq_1                             | fastq_2                             | assembly_accession |
+| id         | assembly_fasta            | fastq_1                             | fastq_2                             | assembly_accession |
 |------------|---------------------------|-------------------------------------|-------------------------------------|--------------------|
 | SRR1631112 | /path/to/ERZ1031893.fasta | /path/to/SRR1631112_1.fastq.gz      | /path/to/SRR1631112_2.fastq.gz      | ERZ1031893         |
 

--- a/bin/tsv_for_genome_upload.py
+++ b/bin/tsv_for_genome_upload.py
@@ -252,7 +252,9 @@ class MAGupload:
 
     def process_mags(self):
         # genomes
-        genomes_list, stats_software, genome_paths = self.get_genomes_info()
+        original_genomes_list, stats_software, genome_paths = self.get_genomes_info()
+        # add genome_type to alias (genome_name)
+        genomes_list = [s + self.genome_type for s in original_genomes_list]
         self.output_table = pd.DataFrame({COLUMNS["genome_name"]: genomes_list})
         self.output_table.set_index(COLUMNS["genome_name"], inplace=True)
         self.output_table[COLUMNS["genome_path"]] = genome_paths

--- a/bin/tsv_for_genome_upload.py
+++ b/bin/tsv_for_genome_upload.py
@@ -252,10 +252,11 @@ class MAGupload:
 
     def process_mags(self):
         # genomes
-        original_genomes_list, stats_software, genome_paths = self.get_genomes_info()
-        # add genome_type to alias (genome_name)
-        genomes_list = [s + self.genome_type for s in original_genomes_list]
-        self.output_table = pd.DataFrame({COLUMNS["genome_name"]: genomes_list})
+        genomes_list, stats_software, genome_paths = self.get_genomes_info()
+        # change name from "ERR10033185_17039" to "ERR10033185_17039_bin/mag"
+        genome_type_singular = self.genome_type.split('s')[0]
+        alias_list = [f"{name.split('.')[0]}_{genome_type_singular}.{name.split('.')[1]}" for name in genomes_list]
+        self.output_table = pd.DataFrame({COLUMNS["genome_name"]: alias_list})
         self.output_table.set_index(COLUMNS["genome_name"], inplace=True)
         self.output_table[COLUMNS["genome_path"]] = genome_paths
         # run accessions

--- a/bin/tsv_for_genome_upload.py
+++ b/bin/tsv_for_genome_upload.py
@@ -253,9 +253,12 @@ class MAGupload:
     def process_mags(self):
         # genomes
         genomes_list, stats_software, genome_paths = self.get_genomes_info()
-        # change name from "ERR10033185_17039" to "ERR10033185_17039_bin/mag"
+        # change name from "ERR10033185_17039.fa" to "ERR10033185_17039_bin/mag.fa"
         genome_type_singular = self.genome_type.split('s')[0]
-        alias_list = [f"{name.split('.')[0]}_{genome_type_singular}.{name.split('.')[1]}" for name in genomes_list]
+        alias_list = []
+        for name in genomes_list:
+            run_and_bin_id, extension = name.split('.')
+            alias_list.append(f"{run_and_bin_id}_{genome_type_singular}.{extension}")
         self.output_table = pd.DataFrame({COLUMNS["genome_name"]: alias_list})
         self.output_table.set_index(COLUMNS["genome_name"], inplace=True)
         self.output_table[COLUMNS["genome_path"]] = genome_paths

--- a/modules/ebi-metagenomics/binette/main.nf
+++ b/modules/ebi-metagenomics/binette/main.nf
@@ -87,7 +87,8 @@ process BINETTE {
     if [ -d "final_bins" ] && [ "\$(ls -A final_bins)" ]; then
         for file in final_bins/*.fa*; do
             if [ -f "\$file" ]; then
-                mv "\$file" "final_bins/${meta.id}_\$(basename "\$file")"
+                bin_number = echo \${file} | cut -f 2 -d '_'
+                mv "\$file" "final_bins/${meta.id}_\${bin_number}"
             fi
         done
 

--- a/modules/ebi-metagenomics/binette/main.nf
+++ b/modules/ebi-metagenomics/binette/main.nf
@@ -87,8 +87,8 @@ process BINETTE {
     if [ -d "final_bins" ] && [ "\$(ls -A final_bins)" ]; then
         for file in final_bins/*.fa*; do
             if [ -f "\$file" ]; then
-                bin_number = echo \${file} | cut -f 2 -d '_'
-                mv "\$file" "final_bins/${meta.id}_\${bin_number}"
+                bin_number=\$(basename "\$file" | cut -f 2 -d '_')   # from bin_1.fa to _1.fa
+                mv "\$file" "final_bins/${meta.id}_\$bin_number"
             fi
         done
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -183,7 +183,7 @@ manifest {
     description     = """Microbiome Informatics MAGs generation pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '1.1.1'
+    version         = '1.3.2'
     doi             = ''
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -38,7 +38,7 @@ params {
     biomes                                  = ""
     centre_name                             = ""
     test_upload                             = false
-    upload_tpa                              = true
+    upload_tpa                              = false
     upload_force                            = false
     upload_mags                             = false
     upload_bins                             = false

--- a/subworkflows/local/samplesheet_generation.nf
+++ b/subworkflows/local/samplesheet_generation.nf
@@ -75,7 +75,9 @@ workflow SAMPLESHEET_GENERATION
 
     // --- assembly software file ---
     if (params.assembly_software_file) {
-        assembly_software = file(params.assembly_software_file, checkIfExists: true)
+        assembly_software = channel.value(
+            file(params.assembly_software_file, checkIfExists: true)
+        )
     }
     else {
         assembly_software = assembly_and_reads

--- a/subworkflows/local/upload.nf
+++ b/subworkflows/local/upload.nf
@@ -59,10 +59,13 @@ workflow UPLOAD_MAGS {
         [prefix, bin]
     }
     manifests_ch = CREATE_MANIFESTS_FOR_UPLOAD.out.manifests.flatten()
-        .map { manifest ->
+        .combine(mags_or_bins_flag)
+        .map { manifest, genome_type ->
         // remove timestamp (added if test_upload = true) and extension from manifest name
         def prefix = manifest.name.replaceAll(/(_\d+)(?:_.*)?\.manifest$/, '$1')
-        [prefix, manifest]
+        // add bin or mag to alias depending on submission type
+        def genome_name = "${prefix}_${genome_type}"
+        [genome_name, manifest]
         }
     combined_ch = mags_ch.join(manifests_ch)
 

--- a/subworkflows/local/upload.nf
+++ b/subworkflows/local/upload.nf
@@ -59,13 +59,10 @@ workflow UPLOAD_MAGS {
         [prefix, bin]
     }
     manifests_ch = CREATE_MANIFESTS_FOR_UPLOAD.out.manifests.flatten()
-        .combine(mags_or_bins_flag)
-        .map { manifest, genome_type ->
+        .map { manifest ->
         // remove timestamp (added if test_upload = true) and extension from manifest name
         def prefix = manifest.name.replaceAll(/(_\d+)(?:_.*)?\.manifest$/, '$1')
-        // add bin or mag to alias depending on submission type
-        def genome_name = "${prefix}_${genome_type}"
-        [genome_name, manifest]
+        [prefix, manifest]
         }
     combined_ch = mags_ch.join(manifests_ch)
 


### PR DESCRIPTION
We now call genomes `ERR[0-9]*_1.fa` and assign an extra "bin"/"mag" suffix depending on the selected upload type. This allows for both mags and bins from the same project to be uploaded to the same webin profile. 

Changed assembly_software so that it's always a "channel" type - calling .subscribe on a path/file object was making it unhappy

I'd recommend changing `--upload_tpa` as default `false` and set it as true just for our usage - in real life people rarely upload someone else's data. Plus, I am personally not able to make flags work with "--upload_tpa"==false and similar, I can only call them and set them true... Feels more intuitive